### PR TITLE
ユーザー詳細画面

### DIFF
--- a/hooks/authentication.ts
+++ b/hooks/authentication.ts
@@ -44,7 +44,8 @@ export function useAuthentication(): { user: User } {
       if (firebaseUser) {
         const loginUser: User = {
           uid: firebaseUser.uid,
-          isAnonymous: firebaseUser.isAnonymous
+          isAnonymous: firebaseUser.isAnonymous,
+          name: ''
         }
         setUser(loginUser)
         createUserIfNotFound(loginUser)

--- a/models/User.ts
+++ b/models/User.ts
@@ -1,4 +1,5 @@
 export type User = {
   uid: string
   isAnonymous: boolean
+  name: string
 }

--- a/pages/users/[uid].tsx
+++ b/pages/users/[uid].tsx
@@ -1,0 +1,8 @@
+import { NextRouter, useRouter } from 'next/router'
+
+const UserShow: React.FC = () => {
+  const router: NextRouter = useRouter()
+  return <div>{router.query.uid}</div>
+}
+
+export default UserShow

--- a/pages/users/[uid].tsx
+++ b/pages/users/[uid].tsx
@@ -1,8 +1,51 @@
+/* eslint-disable no-console */
 import { NextRouter, useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { User } from '../../models/User'
+import firebase from 'firebase/app'
+
+const defaultUser: User = {
+  uid: '',
+  isAnonymous: true,
+  name: ''
+}
+
+type Query = {
+  uid: string
+}
 
 const UserShow: React.FC = () => {
+  const [user, setUser] = useState<User>(defaultUser)
   const router: NextRouter = useRouter()
-  return <div>{router.query.uid}</div>
+  const query = router.query as Query
+
+  useEffect(() => {
+    if (query.uid === undefined) {
+      return
+    }
+
+    const loadUser = async () => {
+      const doc = await firebase
+        .firestore()
+        .collection('users')
+        .doc(query.uid)
+        .get()
+
+      if (!doc.exists) {
+        // console.log('returned!')
+        // console.log(user?.name)
+        return
+      }
+
+      const gotUser = doc.data() as User
+      gotUser.uid = doc.id
+      setUser(gotUser)
+    }
+    loadUser()
+  }, [query.uid])
+
+  // defaultUserが表示されるので、nameがからのときに
+  return <div>{user.name.length ? user.name : 'now loading ...'}</div>
 }
 
 export default UserShow


### PR DESCRIPTION
* https://zenn.dev/dala/books/nextjs-firebase-service/viewer/user-detail-page
* 現状、uidをURLに直打ちして表示 ``localhost:3000/users/uid``